### PR TITLE
[FEAT](l10n_mx_edi): ajustar descripción de nota de crédito para uso …

### DIFF
--- a/l10n_mx_edi_cfdi_G02/__init__.py
+++ b/l10n_mx_edi_cfdi_G02/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_mx_edi_cfdi_G02/__manifest__.py
+++ b/l10n_mx_edi_cfdi_G02/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'corrección uso CFDI G02',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'summary': 'Ajuste para que los CFDI con uso G02 tengan la descripción correcta en los conceptos.',
+    'author': 'Ezzquad',
+    'depends': ['l10n_mx_edi'],
+    'data': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/l10n_mx_edi_cfdi_G02/models/__init__.py
+++ b/l10n_mx_edi_cfdi_G02/models/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_mx_edi_document

--- a/l10n_mx_edi_cfdi_G02/models/l10n_mx_edi_document.py
+++ b/l10n_mx_edi_cfdi_G02/models/l10n_mx_edi_document.py
@@ -1,0 +1,29 @@
+from odoo import models, api
+
+
+class L10nMxEdiDocument(models.Model):
+    _inherit = "l10n_mx_edi.document"
+
+    def _add_base_lines_cfdi_values(self, cfdi_values, base_lines, percentage_paid=None):
+        super()._add_base_lines_cfdi_values(
+            cfdi_values,
+            base_lines,
+            percentage_paid
+        )
+        
+        is_refound_gi = cfdi_values['receptor']['uso_cfdi'] == 'G02'
+        base_lines_map = {line['record']: line for line in base_lines}
+        
+        if not is_refound_gi:
+            return
+        
+        for base_line_values in cfdi_values('conceptos_list', []):
+                line = base_line_values.get('line',{}).get('record')
+                base_line = base_lines_map.get(line)
+                
+                if base_line.get('name') == "":
+                    description = "Devoluciones, descuentos o bonificaciones"
+                else:
+                    description = base_line.get('name')
+                
+                base_line_values['description'] = description.get('name')


### PR DESCRIPTION
…G02 en el modulo de factura

Hereda y extiende la función l10n_mx_edi para modificar el comportamiento del XML. Cuando el uso de CFDI sea "G02" (Devoluciones, descuentos o bonificaciones), se incluirá la descripción de la nota de crédito en el nodo correspondiente.